### PR TITLE
Hotfix prepublish and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### From the CDN:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/camp-css@latest/dist/camp.min.css">
+<link rel="stylesheet" href="https://unpkg.com/camp-css@latest/css/camp.min.css">
 ```
 
 ### As a package

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:prod": "npm run compile && postcss css/camp.css --env production -o css/camp.min.css -m",
     "start": "watch \"npm run build\" scss",
     "dev": "npm run clean && npm start",
-    "prepublish": "npm run clean && npm run lint && npm run test && npm run build:prod"
+    "prepublish": "npm run clean && npm run lint && npm run test && npm run build && npm run build:prod"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camp-css",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CSS behind the distinctive style of ActiveCampaign",
   "style": "css/camp.min.css",
   "main": "css/camp.css",


### PR DESCRIPTION
Fixes prepublish command and readme
- fixes link to cnd in readme
- adds normal build to prepublish script

@ActiveCampaign/site 