### PR TITLE
0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 ### Added
 
+## [0.11.1] - 2018-08-10
+### Changed
+- Base icon size variables on the base scale value
+- Update readme
+
 ## [0.11.0] - 2018-08-10
 ### Changed
 - Base font color changed from $slate to $slate-120
-- Base icon sizes on the base scale
 
 ### Added
 - Add classes for icon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Base font color changed from $slate to $slate-120.
+### Added
+
+## [0.11.0] - 2018-08-10
+### Changed
+- Base font color changed from $slate to $slate-120
+
+### Added
+- Add classes for icon
 
 ## [0.10.1] - 2018-08-08
 ### Added
-- create type classes that mirror styles from the type mixins
+- Create type classes that mirror styles from the type mixins
 - Mixin for responsive breakpoints
 
 ### Changed
-- remove build process from the preversion the npm script
-- lead-in title letter spacing to 5% of its font size
+- Remove build process from the preversion the npm script
+- Lead-in title letter spacing to 5% of its font size
 
 ## [0.9.0] - 2018-08-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0] - 2018-08-10
 ### Changed
 - Base font color changed from $slate to $slate-120
+- Base icon sizes on the base scale
 
 ### Added
 - Add classes for icon

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 <link rel="stylesheet" href="https://unpkg.com/camp-css@latest/css/camp.min.css">
 ```
 
-### As a package
+### From yarn
 
 ```sh
 yarn add camp-css
 ```
 
-With npm:
+### From npm
 
 ```sh
 npm install camp-css

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "camp-css",
-  "version": "0.10.1",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camp-css",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "CSS behind the distinctive style of ActiveCampaign",
   "style": "css/camp.min.css",
   "main": "css/camp.css",

--- a/scss/variables/_icons.scss
+++ b/scss/variables/_icons.scss
@@ -1,5 +1,5 @@
 $icon-sizes: (
-  s: 32px,
-  m: 64px,
-  l: 128px
+  s: $base-scale * 8, // 32px
+  m: $base-scale * 16, // 64px
+  l: $base-scale * 32, // 128px
 );


### PR DESCRIPTION
Base the icon variable calculation on the `$base-scale` value rather than explicitly setting pixel values. 

- changed changelog
- changed readme
- changed version to 0.11.1

@ActiveCampaign/site 