### PR TITLE
Add text-decoration transition to link pseudo classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.14.5] - 2018-10-25
+### Fixed
+- Add text-decoration transition to `link` pseudo classes.
+
+## [0.14.4] - 2018-10-22
 ### Changed
 - Add text-decoration transition to the `link` class.
 

--- a/scss/_link.scss
+++ b/scss/_link.scss
@@ -6,19 +6,27 @@
 
   &:link,
   &:visited {
-    transition: color $transition-duration-slow $transition-function;
+    transition:
+    color $transition-duration-slow $transition-function,
+    text-decoration $transition-duration-slow $transition-function;
   }
 
   &:hover   {
-    transition: color $transition-duration-slow $transition-function;
+    transition:
+    color $transition-duration-slow $transition-function,
+    text-decoration $transition-duration-slow $transition-function;
   }
 
   &:active  {
-    transition: color $transition-duration-slow $transition-function;
+    transition:
+    color $transition-duration-slow $transition-function,
+    text-decoration $transition-duration-slow $transition-function;
   }
 
   &:focus   {
-    transition: color $transition-duration-slow $transition-function;
+    transition:
+    color $transition-duration-slow $transition-function,
+    text-decoration $transition-duration-slow $transition-function;
     outline: rem(1px dotted currentColor);
   }
 }


### PR DESCRIPTION
This was supposed to happen in the previous release but I didn't add it to the pseudo classes for some reason.

@ActiveCampaign/site 