### PR TITLE
define what filed are pulled when someone installs camp-css as a dependecy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode/
 node_modules
 npm-debug.log
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
   "bugs": {
     "url": "https://github.com/activecampaign/camp-css/issues"
   },
+  "files": [
+    "css/*",
+    "scss/*"
+  ],
   "homepage": "https://github.com/activecampaign/camp-css#readme",
   "devDependencies": {
     "autoprefixer": "^9.1.1",


### PR DESCRIPTION
Specifies what files are pulled when someone does an `npm i camp-css`; in this case, only the `css/` and `scss/` folders. Additionally, certain files, like `package.json` and `CHANGELOG` will be automatically included and do not need to be defined here.