### PR TITLE
Use $base-font-size variable instead of hardcoded 16px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.14.7] - 2019-01-16
+### Changed
+- Use $base-font-size var in rem() function instead of hard-coded value.
+
 ## [0.14.6] - 2018-10-31
 ### Fixed
 - Place margin column classes inside the media query loop.

--- a/scss/camp.scss
+++ b/scss/camp.scss
@@ -1,5 +1,6 @@
 // Scale
 $base-scale: 4px;
+$base-font-size: 16px; // The assumed font-size of the document element. Used when converting px to rem.
 
 // Variables
 @import 'variables/borders';

--- a/scss/camp.scss
+++ b/scss/camp.scss
@@ -1,6 +1,12 @@
 // Scale
 $base-scale: 4px;
-$base-font-size: 16px; // The assumed font-size of the document element. Used when converting px to rem.
+
+// Base Font Size
+//
+// Should represent the font-size of the root element, in pixels,
+// if a font-size has been declared for it. Used when converting px to rem.
+// If font-size on root is `100%` or not declared, this should be `16px`.
+$base-font-size: 16px;
 
 // Variables
 @import 'variables/borders';

--- a/scss/utilities/functions/_rem.scss
+++ b/scss/utilities/functions/_rem.scss
@@ -5,7 +5,7 @@
     $v: nth($value, $i);
 
     @if is-absolute-length($v) {
-      $result: append($result, ($v / 16px) * 1rem);
+      $result: append($result, ($v / $base-font-size) * 1rem);
     }
 
     @else {


### PR DESCRIPTION
## Problem
Our function for converting values to rem has `16px` hardcoded. This assumes that the `font-size` on`<html>` is `100%`. This is true if someone is importing the entirety of camp-css since we set it in the `reset.scss` file and in all major browsers 100% = 16px by default. However if someone does not import the reset file AND has a value set for the HTML/document font-size other than 16px or 100%, the rem calculations will be all messed up.

## Solution
Use a Sass variable instead of the hardcoded value. This is similar to what we do with the `$base-scale` variable and that works great when importing only certain files from camp-css. This way you can set the new variable `$base-font-size` to whatever your HTML font-size is and the rem calculations will all work correctly.

@ActiveCampaign/site 