### PR TITLE
Added link to codepen

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ If you have installed camp as a package and would like to reference the variable
 @import 'camp-css/scss/camp';
 ```
 
+## Examples
+Nick Ciliak was gracious enough to create a few examples of camp-css in action
+[on codepen](https://codepen.io/collection/DBRyYY/).
+
 ## Contributing
 
 1. Create a fork of the `ActiveCampaign/camp-css` repository.


### PR DESCRIPTION
# Description
I just added a link to codepen examples to the readme for easy access. I didn't include any of the Zeplin links because they are private. 

As this is a public repo, I didn't think that linking to confluence made sense either. 